### PR TITLE
chore(ci): update the pact docker to v4.13.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   test-pact-v4:
     runs-on: ubuntu-latest
     env:
-      PACT_VERSION: v4.12.0
+      PACT_VERSION: v4.13.0
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
With the release of pact v4.13.0 the ci tests should be updated to include the latest change.